### PR TITLE
Fix nvim-tree filter option

### DIFF
--- a/lua/plugins/nvim-tree.lua
+++ b/lua/plugins/nvim-tree.lua
@@ -88,10 +88,10 @@ return function()
         mappings = {
           custom_only = true,
           list = nvim_tree_bindings
-        },
-        filters = {
-          dotfiles = false
         }
+      },
+      filters = {
+        dotfiles = false
       }
     }
 end


### PR DESCRIPTION
Hi, I found a small error about the filter option of nvim-tree. It's an option by itself and not a property of the view options.